### PR TITLE
Add three-panel layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,38 +1,26 @@
 .App {
+  display: flex;
+  height: 100vh;
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.panel {
+  flex: 1;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  font-size: 2rem;
 }
 
-.App-link {
-  color: #61dafb;
+.left {
+  background-color: #f5f5f5;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.center {
+  background-color: #e0e0e0;
 }
+
+.right {
+  background-color: #f5f5f5;
+}
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,11 @@
-import logo from './logo.svg';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <div className="panel left">Left Panel</div>
+      <div className="panel center">Center Panel</div>
+      <div className="panel right">Right Panel</div>
     </div>
   );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders left, center, and right panels', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/left panel/i)).toBeInTheDocument();
+  expect(screen.getByText(/center panel/i)).toBeInTheDocument();
+  expect(screen.getByText(/right panel/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Replace boilerplate content with left, center, and right panels
- Add flexbox styling for panel layout
- Update tests to check for all three panels

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77afe847883328add2f92681b6e96