### PR TITLE
Add resizable panels with central canvas

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,15 +1,22 @@
 .App {
-  display: flex;
+  display: grid;
+  grid-template-columns: 200px 5px 400px 5px 1fr;
   height: 100vh;
   text-align: center;
 }
 
 .panel {
-  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 2rem;
+  overflow: hidden;
+}
+
+.resizer {
+  width: 5px;
+  cursor: col-resize;
+  background-color: #ccc;
 }
 
 .left {
@@ -20,7 +27,12 @@
   background-color: #e0e0e0;
 }
 
+.center canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .right {
   background-color: #f5f5f5;
 }
-

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,46 @@
+import { useState } from 'react';
 import './App.css';
 
 function App() {
+  const [leftWidth, setLeftWidth] = useState(200);
+  const [centerWidth, setCenterWidth] = useState(400);
+
+  const startResizing = (panel) => (e) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startLeftWidth = leftWidth;
+    const startCenterWidth = centerWidth;
+
+    const onMouseMove = (e) => {
+      const dx = e.clientX - startX;
+      if (panel === 'left') {
+        setLeftWidth(Math.max(100, startLeftWidth + dx));
+      }
+      if (panel === 'center') {
+        setCenterWidth(Math.max(100, startCenterWidth + dx));
+      }
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
   return (
-    <div className="App">
+    <div
+      className="App"
+      style={{ gridTemplateColumns: `${leftWidth}px 5px ${centerWidth}px 5px 1fr` }}
+    >
       <div className="panel left">Left Panel</div>
-      <div className="panel center">Center Panel</div>
+      <div className="resizer" onMouseDown={startResizing('left')}></div>
+      <div className="panel center">
+        <canvas id="main-canvas" data-testid="drawing-canvas"></canvas>
+      </div>
+      <div className="resizer" onMouseDown={startResizing('center')}></div>
       <div className="panel right">Right Panel</div>
     </div>
   );

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders left, center, and right panels', () => {
+test('renders left and right panels with canvas in center', () => {
   render(<App />);
   expect(screen.getByText(/left panel/i)).toBeInTheDocument();
-  expect(screen.getByText(/center panel/i)).toBeInTheDocument();
   expect(screen.getByText(/right panel/i)).toBeInTheDocument();
+  expect(screen.getByTestId('drawing-canvas')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- allow left, center, and right panels to be resized via draggable dividers
- place a canvas element in the center panel for future drawing features
- adjust tests to confirm presence of canvas

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77d00c5388332af8903869516365e